### PR TITLE
Skip Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,6 @@
 version: 2
 
 jobs:
-  build__CONDA_PY_27:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_PY: "27"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_PY_35:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_PY: "35"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
   build__CONDA_PY_36:
     working_directory: ~/test
     machine: true
@@ -69,6 +27,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_PY_27
-      - build__CONDA_PY_35
       - build__CONDA_PY_36

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_PY=27
-    - CONDA_PY=35
     - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,6 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and py<=35]
+  skip: true  # [py<=35]
   features:
     - vc14    # [win and py>=35]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and py<35]
+  skip: true  # [win and py<=35]
   features:
     - vc14    # [win and py>=35]
 


### PR DESCRIPTION
As Python 3.5 and Python 3.6 on Windows use the same VC runtime, there is no need to build under both Pythons. This skips Python 3.5 as it will be dropped first. Though the choice is arbitrary.